### PR TITLE
added line to remove extra SPAdes files

### DIFF
--- a/type_pipe_2.2.sh
+++ b/type_pipe_2.2.sh
@@ -167,6 +167,17 @@ for i in ${id[@]}; do
     else
         echo 'constructing assemblies for '$i', could take some time...'
          spades.py --pe1-12 ./clean/*${i}*.cleaned.fastq.gz -o spades_assembly_trim/${i}/ --careful
+	 rm -rf ./spades_assembly_trim/$i/corrected \
+		./spades_assembly_trim/$i/K21 \
+                ./spades_assembly_trim/$i/K33 \
+                ./spades_assembly_trim/$i/K55 \
+                ./spades_assembly_trim/$i/K77 \
+                ./spades_assembly_trim/$i/K99 \
+                ./spades_assembly_trim/$i/K127 \
+                ./spades_assembly_trim/$i/misc \
+                ./spades_assembly_trim/$i/mismatch_corrector \
+                ./spades_assembly_trim/$i/split_input \
+                ./spades_assembly_trim/$i/tmp
     fi
 done
 


### PR DESCRIPTION
Tested by running the `run_type_pipe` script to run spades on one E coli isolate. Checked the isolate's spades folder afterwards and all of the directories specified were removed successfully